### PR TITLE
Add support for multiple mail servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ language: php
 #  - linux
 #  - osx
 
-sudo: false
-
 install:
   # Ignore composer.lock to test against current versions of dependencies.
   - rm -f composer.lock

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Mailbox Authentication Plugin for Joomla!
 =========================================
 
-This is a Joomla! plugin to authenticate users against a mail server via IMAP,
-NNTP, or POP3.  It forwards authentication credentials provided by the user to
-a mail server, then relays the authentication decision of the mail server back
-to Joomla!.
+This is a Joomla! plugin to authenticate users against one or more mail
+servers via IMAP, NNTP, or POP3.  It forwards authentication credentials
+provided by the user to one or more mail servers, then relays the
+authentication decision of the mail servers back to Joomla!.
 
 In simpler terms, it lets users log in to Joomla! with the same username and
 password that they use for email, without the need to copy and synchronize the
@@ -19,6 +19,7 @@ accounts manually.
  * Optionally require secure (non-plaintext) authentication.
  * Support for TLS (optional or required) and SSL.
  * Optional validation of SSL certificate from mail server.
+ * Authentication against multiple mail servers.
  * Supports the [Joomla! Update
    System](https://docs.joomla.org/Help36:Extensions_Extension_Manager_Update).
 
@@ -28,9 +29,6 @@ accounts manually.
  * Does not integrate email/webmail into Joomla! or provide Single Sign-On
    (SSO) between email/webmail and Joomla!  Meaning users will still need to
    login to both Joomla! and email/webmail separately.
- * Authentication against multiple mail servers.  Currently this plugin only
-   supports authentication against a single mail server (although the address
-   to which it connects may be load-balanced to multiple servers transparently).
 
 
 ### Plugin Requirements

--- a/language/en-GB/en-GB.plg_authentication_mailbox.ini
+++ b/language/en-GB/en-GB.plg_authentication_mailbox.ini
@@ -1,6 +1,7 @@
 ; British English Language File
 
 ; Parameter names and descriptions
+PLG_AUTH_MAILBOX_TARGETLISTLABEL="Mailbox Servers"
 PLG_AUTH_MAILBOX_DOMAINLABEL="Default Mail Domain"
 PLG_AUTH_MAILBOX_DOMAINDESC="Domain appended to usernames which lack a domain, to create the email address used for the Joomla! account."
 PLG_AUTH_MAILBOX_DOMAINUSERLABEL="Include Mail Domain in Mailbox Username"

--- a/language/es-ES/es-ES.plg_authentication_mailbox.ini
+++ b/language/es-ES/es-ES.plg_authentication_mailbox.ini
@@ -1,6 +1,7 @@
 ; Archivo de idioma español de España
 
 ; Nombres de parámetros y descripción
+PLG_AUTH_MAILBOX_TARGETLISTLABEL="Lista de servidores"
 PLG_AUTH_MAILBOX_DOMAINLABEL="Dominio por omisión"
 PLG_AUTH_MAILBOX_DOMAINDESC="Dominio añadido a los nombres de usuario que carezcan del mismo, para crear la dirección de correo de la cuenta de Joomla!"
 PLG_AUTH_MAILBOX_DOMAINUSERLABEL="Incluir dominio en nombre de buzón de correo"

--- a/mailbox.xml
+++ b/mailbox.xml
@@ -58,6 +58,26 @@
 								default="0"
 								/>
 							<field
+								name="mail_server"
+								type="text"
+								required="true"
+								default="localhost"
+								label="PLG_AUTH_MAILBOX_SERVERLABEL"
+								description="PLG_AUTH_MAILBOX_SERVERDESC"
+								/>
+							<field
+								name="mail_protocol"
+								type="list"
+								required="true"
+								default="imap"
+								label="PLG_AUTH_MAILBOX_PROTOLABEL"
+								description="PLG_AUTH_MAILBOX_PROTODESC"
+								>
+								<option value="imap">IMAP</option>
+								<option value="nntp">NNTP</option>
+								<option value="pop3">POP3</option>
+							</field>
+							<field
 								name="mail_domain"
 								type="text"
 								default="example.com"
@@ -85,26 +105,6 @@
 								>
 								<option value="1">JYES</option>
 								<option value="0">JNO</option>
-							</field>
-							<field
-								name="mail_server"
-								type="text"
-								required="true"
-								default="localhost"
-								label="PLG_AUTH_MAILBOX_SERVERLABEL"
-								description="PLG_AUTH_MAILBOX_SERVERDESC"
-								/>
-							<field
-								name="mail_protocol"
-								type="list"
-								required="true"
-								default="imap"
-								label="PLG_AUTH_MAILBOX_PROTOLABEL"
-								description="PLG_AUTH_MAILBOX_PROTODESC"
-								>
-								<option value="imap">IMAP</option>
-								<option value="nntp">NNTP</option>
-								<option value="pop3">POP3</option>
 							</field>
 							<field
 								name="create_users"

--- a/mailbox.xml
+++ b/mailbox.xml
@@ -36,121 +36,144 @@
 	</languages>
 	<config>
 		<fields name="params">
-			<fieldset name="basic">
+			<fieldset
+				name="targets"
+				label="PLG_AUTH_MAILBOX_TARGETLISTLABEL"
+				>
 				<field
-					name="mail_domain"
-					type="text"
-					default="example.com"
-					label="PLG_AUTH_MAILBOX_DOMAINLABEL"
-					description="PLG_AUTH_MAILBOX_DOMAINDESC"
-					/>
-				<field
-					name="mail_domain_username"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="PLG_AUTH_MAILBOX_DOMAINUSERLABEL"
-					description="PLG_AUTH_MAILBOX_DOMAINUSERDESC"
+					name="targets"
+					type="subform"
+					layout="joomla.form.field.subform.repeatable"
+					multiple="true"
+					min="1"
+					groupByFieldset="true"
+					hiddenLabel="true"
 					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
-				<field
-					name="mail_domain_in_joomla_username"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="PLG_AUTH_MAILBOX_DOMAINJUSERLABEL"
-					description="PLG_AUTH_MAILBOX_DOMAINJUSERDESC"
-					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
-				<field
-					name="mail_server"
-					type="text"
-					required="true"
-					default="localhost"
-					label="PLG_AUTH_MAILBOX_SERVERLABEL"
-					description="PLG_AUTH_MAILBOX_SERVERDESC"
-					/>
-				<field
-					name="mail_protocol"
-					type="list"
-					required="true"
-					default="imap"
-					label="PLG_AUTH_MAILBOX_PROTOLABEL"
-					description="PLG_AUTH_MAILBOX_PROTODESC"
-					>
-					<option value="imap">IMAP</option>
-					<option value="nntp">NNTP</option>
-					<option value="pop3">POP3</option>
-				</field>
-				<field
-					name="create_users"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="1"
-					label="PLG_AUTH_MAILBOX_CREATEUSERSLABEL"
-					description="PLG_AUTH_MAILBOX_CREATEUSERSDESC"
-					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
-			</fieldset>
+					<form>
+						<fieldset name="general" label="JGLOBAL_FIELDSET_BASIC">
+							<field
+								name="ordering"
+								type="hidden"
+								hidden="true"
+								default="0"
+								/>
+							<field
+								name="mail_domain"
+								type="text"
+								default="example.com"
+								label="PLG_AUTH_MAILBOX_DOMAINLABEL"
+								description="PLG_AUTH_MAILBOX_DOMAINDESC"
+								/>
+							<field
+								name="mail_domain_username"
+								type="radio"
+								class="btn-group btn-group-yesno"
+								default="0"
+								label="PLG_AUTH_MAILBOX_DOMAINUSERLABEL"
+								description="PLG_AUTH_MAILBOX_DOMAINUSERDESC"
+								>
+								<option value="1">JYES</option>
+								<option value="0">JNO</option>
+							</field>
+							<field
+								name="mail_domain_in_joomla_username"
+								type="radio"
+								class="btn-group btn-group-yesno"
+								default="0"
+								label="PLG_AUTH_MAILBOX_DOMAINJUSERLABEL"
+								description="PLG_AUTH_MAILBOX_DOMAINJUSERDESC"
+								>
+								<option value="1">JYES</option>
+								<option value="0">JNO</option>
+							</field>
+							<field
+								name="mail_server"
+								type="text"
+								required="true"
+								default="localhost"
+								label="PLG_AUTH_MAILBOX_SERVERLABEL"
+								description="PLG_AUTH_MAILBOX_SERVERDESC"
+								/>
+							<field
+								name="mail_protocol"
+								type="list"
+								required="true"
+								default="imap"
+								label="PLG_AUTH_MAILBOX_PROTOLABEL"
+								description="PLG_AUTH_MAILBOX_PROTODESC"
+								>
+								<option value="imap">IMAP</option>
+								<option value="nntp">NNTP</option>
+								<option value="pop3">POP3</option>
+							</field>
+							<field
+								name="create_users"
+								type="radio"
+								class="btn-group btn-group-yesno"
+								default="1"
+								label="PLG_AUTH_MAILBOX_CREATEUSERSLABEL"
+								description="PLG_AUTH_MAILBOX_CREATEUSERSDESC"
+								>
+								<option value="1">JYES</option>
+								<option value="0">JNO</option>
+							</field>
+						</fieldset>
 
-			<fieldset name="advanced">
-				<field
-					name="mail_port"
-					type="text"
-					default=""
-					label="PLG_AUTH_MAILBOX_PORTLABEL"
-					description="PLG_AUTH_MAILBOX_PORTDESC"
-					/>
-				<field
-					name="mail_allow_plaintext"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="PLG_AUTH_MAILBOX_ALLOWPLAINLABEL"
-					description="PLG_AUTH_MAILBOX_ALLOWPLAINDESC"
-					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
-				<field
-					name="mail_encryption"
-					type="list"
-					default="1"
-					label="PLG_AUTH_MAILBOX_ENCRYPTLABEL"
-					description="PLG_AUTH_MAILBOX_ENCRYPTDESC"
-					>
-					<option value="0">PLG_AUTH_MAILBOX_VALENCRYPTNONE</option>
-					<option value="1">PLG_AUTH_MAILBOX_VALENCRYPTTLSOPT</option>
-					<option value="2">PLG_AUTH_MAILBOX_VALENCRYPTTLSREQ</option>
-					<option value="3">PLG_AUTH_MAILBOX_VALENCRYPTSSL</option>
-				</field>
-				<field
-					name="mail_validate_cert"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="1"
-					label="PLG_AUTH_MAILBOX_VALIDCERTLABEL"
-					description="PLG_AUTH_MAILBOX_VALIDCERTDESC"
-					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
-				<field
-					name="show_imap_errors"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="PLG_AUTH_MAILBOX_IMAPERRLABEL"
-					description="PLG_AUTH_MAILBOX_IMAPERRDESC"
-					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
+						<fieldset name="advanced" label="JGLOBAL_FIELDSET_ADVANCED">
+							<field
+								name="mail_port"
+								type="text"
+								default=""
+								label="PLG_AUTH_MAILBOX_PORTLABEL"
+								description="PLG_AUTH_MAILBOX_PORTDESC"
+								/>
+							<field
+								name="mail_allow_plaintext"
+								type="radio"
+								class="btn-group btn-group-yesno"
+								default="0"
+								label="PLG_AUTH_MAILBOX_ALLOWPLAINLABEL"
+								description="PLG_AUTH_MAILBOX_ALLOWPLAINDESC"
+								>
+								<option value="1">JYES</option>
+								<option value="0">JNO</option>
+							</field>
+							<field
+								name="mail_encryption"
+								type="list"
+								default="1"
+								label="PLG_AUTH_MAILBOX_ENCRYPTLABEL"
+								description="PLG_AUTH_MAILBOX_ENCRYPTDESC"
+								>
+								<option value="0">PLG_AUTH_MAILBOX_VALENCRYPTNONE</option>
+								<option value="1">PLG_AUTH_MAILBOX_VALENCRYPTTLSOPT</option>
+								<option value="2">PLG_AUTH_MAILBOX_VALENCRYPTTLSREQ</option>
+								<option value="3">PLG_AUTH_MAILBOX_VALENCRYPTSSL</option>
+							</field>
+							<field
+								name="mail_validate_cert"
+								type="radio"
+								class="btn-group btn-group-yesno"
+								default="1"
+								label="PLG_AUTH_MAILBOX_VALIDCERTLABEL"
+								description="PLG_AUTH_MAILBOX_VALIDCERTDESC"
+								>
+								<option value="1">JYES</option>
+								<option value="0">JNO</option>
+							</field>
+							<field
+								name="show_imap_errors"
+								type="radio"
+								class="btn-group btn-group-yesno"
+								default="0"
+								label="PLG_AUTH_MAILBOX_IMAPERRLABEL"
+								description="PLG_AUTH_MAILBOX_IMAPERRDESC"
+								>
+								<option value="1">JYES</option>
+								<option value="0">JNO</option>
+							</field>
+						</fieldset>
+					</form>
 				</field>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
This pull request is based on the multi-server version of the plugin that @mperaya posted in https://github.com/kevinoid/auth-mailbox-joomla/issues/3#issuecomment-449068699.  Several of the improvements from his version (including the es-ES language files) are already included in [v1.0.10](https://github.com/kevinoid/auth-mailbox-joomla/releases/tag/v1.0.10).  This PR is to consider the multi-server support specifically.  It also does not include the very impressive repeatable tab layout that @mperaya created, which may be considered in a future PR.

This PR has a few known technical issues that should be fixed before it is merged:

- [ ] Configuration is lost when upgrading from previous versions.  Perhaps the configuration could be migrated in `update` method of an [install script](https://docs.joomla.org/J3.x:Creating_a_simple_module/Adding_an_install-uninstall-update_script_file)?
- [ ] The configuration form has lots of empty space on the left margin.  I think it is a bug in `layout="joomla.form.field.subform.repeatable"` that when `hiddenLabel` is `true` the label space is not removed ([as it is for `groupByFieldset` in `repeatable-table`](https://github.com/joomla/joomla-cms/blob/staging/layouts/joomla/form/field/subform/repeatable-table.php#L64-L67)).  It's low priority, but should be discussed with Joomla! developers.

I am still considering whether this feature justifies the additional complexity and maintenance burden, and if so, how best to implement it.  I'd appreciate feedback from potential users, particularly about the following issues:

**Should the login username be tried on all servers?**  If so, login will be slow for later servers and there is a risk that the Joomla! server will be blacklisted by the mail server based on the number of failed login attempts.  If not, how should this be configured?

This PR currently attempts authentication when the login username either matches the Default Domain or doesn't contain a domain.  This is simple and understandable, but limiting.  It prevents use when a server serves multiple mail domains.  Checking the login username against a configurable regular expression for each server would be another option.

**How should the plugin handle conflicting usernames?**  If "Include Mail Domain in Joomla! Username" is "No" in the plugin configuration, users on different servers would authenticate as the same Joomla! account.  This could cause problems and allow account stealing by users who can create new email accounts on the mailbox servers.  Can this be prevented, or is adding a configuration warning the only reasonable option?

**Which configuration options should be per-server?**  Most of the current configuration options are server-specific.  Some, such as "Create Users", "Include Mail Domain in Joomla! Username", "Show Protocol Errors" may not be.  Are there use cases where it would be desirable to have the mail domain in some usernames but not others, or to only create users from some servers?  "Default Mail Domain" is particularly interesting, since it could be used to try the same username with different domains on different servers (if per-server).  Alternatively, it could be used to map usernames without domains to specific servers (if not per-server).

Feedback on these questions from users with real use cases would be appreciated.  Alternatively, if someone with this use case would like to publish and maintain a multi-server plugin based on this code, I would fully encourage it!